### PR TITLE
fixed bug while formatting iterative output

### DIFF
--- a/debvader/debvader.py
+++ b/debvader/debvader.py
@@ -233,8 +233,8 @@ def deblend_field(net, field_image, galaxy_distances_to_center, cutout_images = 
     res_deblend['cutout_images']=cutout_images
     res_deblend['output_images_mean']=output_images_mean
     res_deblend['output_images_distribution']=output_images_distribution
-    res_deblend['shifts']=shifts
-    res_deblend['list_idx']=list_idx
+    res_deblend['shifts']=list(shifts)
+    res_deblend['list_idx']=list(list_idx)
     res_deblend['nb_of_galaxies_in_model']=int(nb_of_galaxies_in_deblended_field)
 
     return res_deblend
@@ -268,9 +268,9 @@ def iterative_deblending(net, field_image, galaxy_distances_to_center, cutout_im
     denoised_field_epistemic_total = res_step['model_image_epistemic_uncertainty']
     cutout_images_total = res_step['cutout_images']
     output_images_total = res_step['output_images_mean']
-    output_images_distribution = res_deblend['output_images_distribution']
-    shifts = res_deblend['shifts']
-    list_idx = res_deblend['list_idx']
+    output_images_distribution_total = [res_step['output_images_distribution']]
+    shifts = res_step['shifts']
+    list_idx = res_step['list_idx']
     nb_of_galaxies_in_deblended_field_total = res_step['nb_of_galaxies_in_model']
 
     while (len(res_step['shifts'])>len(shifts_previous)):
@@ -292,9 +292,9 @@ def iterative_deblending(net, field_image, galaxy_distances_to_center, cutout_im
         denoised_field_epistemic_total += res_step['model_image_epistemic_uncertainty']
         cutout_images_total = np.concatenate((cutout_images_total, res_step['cutout_images']), axis = 0)
         output_images_total = np.concatenate((output_images_total, res_step['output_images_mean']), axis = 0)
-        output_images_distribution = np.concatenate((output_images_distribution, res_step['output_images_distribution']), axis = 0)
-        shifts +=res_step['shifts']
-        list_idx += res_deblend['list_idx']
+        output_images_distribution_total += [res_step['output_images_distribution']]
+        shifts.extend(res_step['shifts'])
+        list_idx.extend(res_step['list_idx'])
         nb_of_galaxies_in_deblended_field_total += res_step['nb_of_galaxies_in_model']
         diff_mse = res_step['mse_step']-mse_step_previous
         k+=1
@@ -314,10 +314,10 @@ def iterative_deblending(net, field_image, galaxy_distances_to_center, cutout_im
     res_total['model_image_epistemic_uncertainty']=denoised_field_epistemic_total
     res_total['cutout_images']=cutout_images_total
     res_total['output_images_mean']=output_images_total
-    res_total['output_images_distribution']=output_images_distribution
+    res_total['output_images_distribution']=output_images_distribution_total
     res_total['shifts'] = shifts
     res_total['list_idx'] = list_idx
-    res_total['nb_of_galaxies_in_model'] = nb_of_galaxies_in_model
+    res_total['nb_of_galaxies_in_model'] = nb_of_galaxies_in_deblended_field_total
 
     return res_total
 


### PR DESCRIPTION
This should have been in the last PR. 
There was a bug when creating the output dictionary of iterative deblending