### PR TITLE
Enable the use of pre-commit

### DIFF
--- a/.github/workflows/check_style.yml
+++ b/.github/workflows/check_style.yml
@@ -1,0 +1,16 @@
+name: "Check code style"
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    env:
+      SKIP: no-commit-to-branch
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
     - id: end-of-file-fixer
     - id: requirements-txt-fixer
     - id: trailing-whitespace
+      args: [--markdown-linebreak-ext=md]
 - repo: https://github.com/PyCQA/isort
   rev: 5.10.1
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.1.0
+  hooks:
+    - id: end-of-file-fixer
+    - id: requirements-txt-fixer
+    - id: trailing-whitespace
+- repo: https://github.com/PyCQA/isort
+  rev: 5.10.1
+  hooks:
+    - id: isort
+      args: [--profile, black]
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.31.0
+  hooks:
+    - id: pyupgrade
+      args: [--py37-plus]
+- repo: https://github.com/PyCQA/flake8
+  rev: 4.0.1
+  hooks:
+   - id: flake8
+     additional_dependencies: [flake8-typing-imports==1.7.0]
+     args: ['--ignore=E501,E203,E731,W503']
+- repo: https://github.com/psf/black
+  rev: 22.1.0
+  hooks:
+    - id: black


### PR DESCRIPTION
`pre-commit` is a framework that can be used to make sure that coding style is enforced throughout the code by any developer.

https://pre-commit.com/

Once installed, it will check locally that every commit enforces the rules defined in the config by running the tools (black, flake8, isort, etc.)