### PR TITLE
Bug fix loss func

### DIFF
--- a/debvader/metrics.py
+++ b/debvader/metrics.py
@@ -24,6 +24,8 @@ def vae_loss(ground_truth, predicted_distribution):
         ground_truth: original ground truth image
         predicted_distribution: distribution predicted by network
     """
-    return -tf.math.reduce_sum(
-        predicted_distribution.log_prob(ground_truth), axis=[1, 2, 3]
+    return -tf.math.reduce_mean(
+        tf.math.reduce_sum(
+            predicted_distribution.log_prob(ground_truth), axis=[1, 2, 3]
+        )
     )

--- a/debvader/metrics.py
+++ b/debvader/metrics.py
@@ -18,7 +18,9 @@ def vae_loss(ground_truth, predicted_distribution):
     """
     computes the reconstruction loss term for the VAE.
 
-    returns the negative log_prob of the ground truth under the predicted distribution
+    The function takes as input the output of the decoder which is a distribution for each pixel.
+    It first calculates the probability of each pixel ground truth under the predicted distrib,
+    sums over all the pixels in an image, and finally returns the average over the batch.
 
     parameters:
         ground_truth: original ground truth image

--- a/debvader/metrics.py
+++ b/debvader/metrics.py
@@ -1,4 +1,5 @@
 import numpy as np
+import tensorflow as tf
 
 
 def mse(img1, img2):
@@ -17,10 +18,12 @@ def vae_loss(ground_truth, predicted_distribution):
     """
     computes the reconstaruction loss term for the VAE.
 
-    returns the log_prob of the ground truth under the predicted distribution
+    returns the negative log_prob of the ground truth under the predicted distribution
 
     parameters:
         ground_truth: original ground truth image
         predicted_distribution: distribution predicted by network
     """
-    return -predicted_distribution.log_prob(ground_truth)
+    return -tf.math.reduce_sum(
+        predicted_distribution.log_prob(ground_truth), axis=[1, 2, 3]
+    )

--- a/debvader/metrics.py
+++ b/debvader/metrics.py
@@ -16,13 +16,13 @@ def mse(img1, img2):
 # Define the loss as the log likelihood of the distribution on the image pixels
 def vae_loss(ground_truth, predicted_distribution):
     """
-    computes the reconstaruction loss term for the VAE.
+    computes the reconstruction loss term for the VAE.
 
     returns the negative log_prob of the ground truth under the predicted distribution
 
     parameters:
         ground_truth: original ground truth image
-        predicted_distribution: distribution predicted by network
+        predicted_distribution: output distribution from the decoder network
     """
     return -tf.math.reduce_mean(
         tf.math.reduce_sum(


### PR DESCRIPTION
previously the function was returning a loss of dimension [batch_size, 59, 59, 6], where 59, 59, 6 is the dimension of input image. 
This is not the expected dimension for a custom TensorFlow loss function. 

Now with a scalar return type, the model trains much better. 