### PR TITLE
Reset encoder weights

### DIFF
--- a/debvader/metrics.py
+++ b/debvader/metrics.py
@@ -14,6 +14,7 @@ def mse(img1, img2):
 
 
 # Define the loss as the log likelihood of the distribution on the image pixels
+@tf.function
 def vae_loss(ground_truth, predicted_distribution):
     """
     computes the reconstruction loss term for the VAE.

--- a/debvader/model.py
+++ b/debvader/model.py
@@ -62,6 +62,8 @@ def create_encoder(
 
     h = Flatten()(h)
     h = PReLU()(h)
+    h = Dense(1024)(h)
+    h = PReLU()(h)
     h = Dense(
         tfp.layers.MultivariateNormalTriL.params_size(latent_dim),
         activation=None,
@@ -86,7 +88,7 @@ def create_decoder(
         kernels: kernels used for the convolutional layers
     """
     input_layer = Input(shape=(latent_dim,))
-    h = Dense(tfp.layers.MultivariateNormalTriL.params_size(32))(input_layer)
+    h = Dense(128)(input_layer)
     h = PReLU()(h)
     w = int(np.ceil(input_shape[0] / 2 ** (len(filters))))
     h = Dense(w * w * filters[-1], activation=None)(tf.cast(h, tf.float32))
@@ -174,6 +176,7 @@ def create_model_vae(
     z = tfp.layers.MultivariateNormalTriL(
         latent_dim,
         activity_regularizer=tfp.layers.KLDivergenceRegularizer(prior, weight=0.01),
+        name="latent_space",
     )(encoder(x_input))
 
     net = Model(inputs=x_input, outputs=decoder(z))

--- a/debvader/model.py
+++ b/debvader/model.py
@@ -128,7 +128,7 @@ def create_decoder(
     # Build the encoder only
     h = tfp.layers.DistributionLambda(
         make_distribution_fn=lambda t: tfd.Normal(
-            loc=t[..., : input_shape[-1]], scale=1e-4 + t[..., input_shape[-1] :]
+            loc=t[..., : input_shape[-1]], scale=1e-6 + t[..., input_shape[-1] :]
         ),
         convert_to_tensor_fn=tfp.distributions.Distribution.sample,
     )(h)

--- a/debvader/model.py
+++ b/debvader/model.py
@@ -88,7 +88,7 @@ def create_decoder(
         kernels: kernels used for the convolutional layers
     """
     input_layer = Input(shape=(latent_dim,))
-    h = Dense(128)(input_layer)
+    h = Dense(256)(input_layer)
     h = PReLU()(h)
     w = int(np.ceil(input_shape[0] / 2 ** (len(filters))))
     h = Dense(w * w * filters[-1], activation=None)(tf.cast(h, tf.float32))

--- a/debvader/train.py
+++ b/debvader/train.py
@@ -260,6 +260,11 @@ def train_deblender(
     train_encoder = True
     train_decoder = False
 
+    new_encoder = model.create_encoder(
+        input_shape=input_shape, latent_dim=latent_dim, filters=filters, kernels=kernels
+    )
+    net.get_layer("encoder").set_weights(new_encoder.get_weights())
+
     deblender_weights_path = os.path.join(weights_save_path, "deblender")
     # Do the training for the deblender
     hist_deblender = train_network(


### PR DESCRIPTION
By observing the result on the reconstructions I note the following:

- The model works well for reconstructing isolated galaxies 
- When it comes to deblending, the flux from neighbouring galaxies leak into the predicted central galaxy. 

My hypothesis here is that when I train the entire VAE in the first iteration, I train it with only isolated galaxies (noiseless) as input and the VAE learns to reconstruct everything that is in the image. The Encoder learns to encode all the flux in the image into the latent space. 
Now, when I start the second iteration using the same encoder, I am starting from a minima where the encoder knows to encode all the information in the image into the latent space. Starting from this point might not be a good idea when trying to deblending because, in the 2nd round of training, I want the encoder to reject the flux not coming from the central galaxy.

So this PR does the following:

- [x] reset the encoder to random weights before the second round of training
- [x] make the model for encoder more complex (more parameters) than the decoder because the encoder is in-charge of the deblending.